### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Example extending `button`:
 
 #### Using a custom element
 
-After registration, you can constructor an instance of your element just like
+After registration, you can construct an instance of your element just like
 standard DOM elements:
 
     <x-foo></x-foo>


### PR DESCRIPTION
Found and fixed a minor typo in the README for CustomElements on the doc site.
