### PR TITLE
Override for CustomElement cloneNode

### DIFF
--- a/src/CustomElements.js
+++ b/src/CustomElements.js
@@ -290,14 +290,27 @@ function upgradeElement(inElement) {
     return definition && upgrade(inElement, definition);
   }
 }
+
+function cloneNode(deep) {
+  // call original clone
+  var n = domCloneNode.call(this, deep);
+  // upgrade the element and subtree
+  scope.upgradeAll(n);
+  return n;
+}
 // capture native createElement before we override it
 
 var domCreateElement = document.createElement.bind(document);
+
+// capture native cloneNode before we override it
+
+var domCloneNode = Node.prototype.cloneNode;
 
 // exports
 
 document.register = register;
 document.createElement = createElement; // override
+Node.prototype.cloneNode = cloneNode; // override
 
 scope.registry = registry;
 

--- a/test/customElements.js
+++ b/test/customElements.js
@@ -203,4 +203,21 @@ suite('customElements', function() {
     xboo.setAttribute('foo', 'bar');
     xboo.setAttribute('foo', 'zot');
   });
+
+  test('node.cloneNode upgrades', function(done) {
+    var XBooPrototype = Object.create(HTMLElement.prototype);
+    XBooPrototype.readyCallback = function() {
+      this.__ready__ = true;
+    };
+    var XBoo = document.register('x-boo-clone', {
+      prototype: XBooPrototype
+    });
+    var xboo = new XBoo();
+    work.appendChild(xboo);
+    setTimeout(function() {
+      var xboo2 = xboo.cloneNode(true);
+      assert(xboo2.__ready__, 'clone readyCallback must be called');
+      done();
+    }, 0);
+  });
 });


### PR DESCRIPTION
- Without this patch, `cloneNode` will not upgrade a cloned element until DOM insertion.
- Added a test, passes in all supported browsers
- Fixes Polymer/CustomElements#28
