### PR TITLE
Fix minified build (by adding missing Observer module and logFlags definition)

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -16,6 +16,7 @@ module.exports = function(grunt) {
     'src/sidetable.js',
     'MutationObservers/MutationObserver.js',
     'src/CustomElements.js',
+    'src/Observer.js',
     'src/HTMLElementElement.js',
     'src/Parser.js',
     'src/boot.js'

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -6,6 +6,9 @@ license that can be found in the LICENSE file.
 
 (function(scope){
 
+// prevent error when loader is not in use/logging not instantiated
+var logFlags = window.logFlags || {};
+
 /*
 if (HTMLElement.prototype.webkitShadowRoot) {
   Object.defineProperty(HTMLElement.prototype, 'shadowRoot', {


### PR DESCRIPTION
Before this change, the `custom-elements.min.js` produced by running `grunt minify` errored out with:

`Uncaught TypeError: Object #<Object> has no method 'upgradeDocument'`.
