### PR TITLE
8/16 master -> stable hotfix

### DIFF
--- a/src/CustomElements.js
+++ b/src/CustomElements.js
@@ -310,7 +310,7 @@ if (useNative) {
     if (definition) {
       return new definition.ctor();
     }
-    return domCreateElement(tag, typeExtension);
+    return domCreateElement(tag);
   }
 
   function upgradeElement(inElement) {


### PR DESCRIPTION
... and causes a problem in Chrome 28 where document.createElement('nav', undefined) results in undefined.

Helps address (https://github.com/Polymer/polymer/issues/243)
