### PR TITLE
Updating enterView/leaveView callbacks to apply only to primary document...

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -8,9 +8,9 @@ license that can be found in the LICENSE file.
 
 var logFlags = window.logFlags || {};
 
-// walk the subtree rooted at node, applying 'find(element, data)' function 
+// walk the subtree rooted at node, applying 'find(element, data)' function
 // to each element
-// if 'find' returns true for 'element', do not search element's subtree  
+// if 'find' returns true for 'element', do not search element's subtree
 function findAll(node, find, data) {
   var e = node.firstElementChild;
   if (!e) {
@@ -37,7 +37,7 @@ function forRoots(node, cb) {
   }
 }
 
-// walk the subtree rooted at node, including descent into shadow-roots, 
+// walk the subtree rooted at node, including descent into shadow-roots,
 // applying 'cb' to each element
 function forSubtree(node, cb) {
   //logFlags.dom && node.childNodes && node.childNodes.length && console.group('subTree: ', node);
@@ -55,7 +55,7 @@ function forSubtree(node, cb) {
 function added(node) {
   if (upgrade(node)) {
     insertedNode(node);
-    return true; 
+    return true;
   }
   inserted(node);
 }
@@ -64,7 +64,7 @@ function added(node) {
 function addedSubtree(node) {
   forSubtree(node, function(e) {
     if (added(e)) {
-      return true; 
+      return true;
     }
   });
 }
@@ -162,8 +162,10 @@ function removed(element) {
 
 function inDocument(element) {
   var p = element;
+  var doc = window.ShadowDOMPolyfill &&
+      window.ShadowDOMPolyfill.wrapIfNeeded(document) || document;
   while (p) {
-    if (p == element.ownerDocument) {
+    if (p == doc) {
       return true;
     }
     p = p.parentNode || p.host;

--- a/test/js/customElements.js
+++ b/test/js/customElements.js
@@ -231,6 +231,41 @@
     assert(xboo2.__ready__, 'clone createdCallback must be called');
     done();
   });
+
+  test('entered left apply to view', function() {
+    var invocations = [];
+    var elementProto = Object.create(HTMLElement.prototype);
+    elementProto.createdCallback = function() {
+      invocations.push('created');
+    }
+    elementProto.enteredViewCallback = function() {
+      invocations.push('entered');
+    }
+    elementProto.leftViewCallback = function() {
+      invocations.push('left');
+    }
+    var tagName = 'x-entered-left-view';
+    var CustomElement = document.register(tagName, { prototype: elementProto });
+
+    var docB = document.implementation.createHTMLDocument('');
+    docB.body.innerHTML = '<' + tagName + '></' + tagName + '>';
+    CustomElements.upgradeAll(docB);
+    CustomElements.takeRecords();
+    assert.deepEqual(invocations, ['created'], 'created but not entered view');
+
+    var element = docB.body.childNodes[0];
+    assert.instanceOf(element, CustomElement, 'element is correct type');
+
+    work.appendChild(element)
+    CustomElements.takeRecords();
+    assert.deepEqual(invocations, ['created', 'entered'],
+        'created and entered view');
+
+    docB.body.appendChild(element);
+    CustomElements.takeRecords();
+    assert.deepEqual(invocations, ['created', 'entered', 'left'],
+        'created, entered then left view');
+  });
 });
 
 htmlSuite('customElements (html)', function() {


### PR DESCRIPTION
The enterView/leaveView callbacks currently fire if the element is within its ownerDocument rather than in the view. This updates the inDocument check to apply to the top-level document.
