### PR TITLE
Making npm package name lower case and adding a peerDependency on mutationobservers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "karma-crbot-reporter": "*"
   },
   "peerDependencies": {
-    "MutationObservers": "git://github.com/briandipalma/MutationObservers"
+    "MutationObservers": "git://github.com/briandipalma/MutationObservers#master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "CustomElements",
+  "name": "customelements",
   "description": "Polyfill for W3C CustomElements Specification",
   "version": "0.0.1",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "karma-crbot-reporter": "*"
   },
   "peerDependencies": {
-    "MutationObservers": "git://github.com/briandipalma/MutationObservers#34a7e828b24824754069bd3c0baf777d63fcc89d"
+    "mutationobservers": ">=0.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "karma-safari-launcher": "*",
     "karma-script-launcher": "*",
     "karma-crbot-reporter": "*"
+  },
+  "dependencies": {
+    "MutationObservers": "git://github.com/briandipalma/MutationObservers"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "karma-crbot-reporter": "*"
   },
   "peerDependencies": {
-    "MutationObservers": "git://github.com/briandipalma/MutationObservers@0.0.0"
+    "MutationObservers": "git://github.com/briandipalma/MutationObservers#34a7e828b24824754069bd3c0baf777d63fcc89d"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "karma-script-launcher": "*",
     "karma-crbot-reporter": "*"
   },
-  "dependencies": {
+  "peerDependencies": {
     "MutationObservers": "git://github.com/briandipalma/MutationObservers"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "karma-crbot-reporter": "*"
   },
   "peerDependencies": {
-    "MutationObservers": "git://github.com/briandipalma/MutationObservers#0.0.0"
+    "MutationObservers": "git://github.com/briandipalma/MutationObservers@0.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "karma-crbot-reporter": "*"
   },
   "peerDependencies": {
-    "MutationObservers": "git://github.com/briandipalma/MutationObservers#master"
+    "MutationObservers": "git://github.com/briandipalma/MutationObservers#0.0.0"
   }
 }


### PR DESCRIPTION
This package is now published to npm I will remove it when the Polymer team publish the packages, I had to start publishing the packages because peerDependencies cannot be simple GitHub URLs as they need to have version information declared as the value of the package key.

`"mutationobservers": ">=0.0.0"`

I couldn't have a GitHub URL where the version is as that prevented me from specifying a version...

https://npmjs.org/package/customelements
