### PR TITLE
Fix inconsistencies with Detach and Attach callbacks when only specifying one of the pair

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -194,7 +194,7 @@ function _removed(element) {
   // TODO(sjmiles): temporary: do work on all custom elements so we can track
   // behavior even when callbacks not defined
   if (element.detachedCallback || (element.__upgraded__ && logFlags.dom)) {
-    logFlags.dom && console.log('removed:', element.localName);
+    logFlags.dom && console.group('removed:', element.localName);
     if (!inDocument(element)) {
       element.__inserted = (element.__inserted || 0) - 1;
       // if we are in a 'inserted' state, bluntly adjust to an 'removed' state
@@ -209,6 +209,7 @@ function _removed(element) {
         element.detachedCallback();
       }
     }
+    logFlags.dom && console.groupEnd();
   }
 }
 

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -151,7 +151,7 @@ function _inserted(element) {
   // TODO(sjmiles): when logging, do work on all custom elements so we can
   // track behavior even when callbacks not defined
   //console.log('inserted: ', element.localName);
-  if (element.attachedCallback || (element.__upgraded__ && logFlags.dom)) {
+  if (element.__upgraded__) {
     logFlags.dom && console.group('inserted:', element.localName);
     if (inDocument(element)) {
       element.__inserted = (element.__inserted || 0) + 1;
@@ -193,7 +193,7 @@ function removed(element) {
 function _removed(element) {
   // TODO(sjmiles): temporary: do work on all custom elements so we can track
   // behavior even when callbacks not defined
-  if (element.detachedCallback || (element.__upgraded__ && logFlags.dom)) {
+  if (element.__upgraded__) {
     logFlags.dom && console.group('removed:', element.localName);
     if (!inDocument(element)) {
       element.__inserted = (element.__inserted || 0) - 1;

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -151,7 +151,7 @@ function _inserted(element) {
   // TODO(sjmiles): when logging, do work on all custom elements so we can
   // track behavior even when callbacks not defined
   //console.log('inserted: ', element.localName);
-  if (element.__upgraded__) {
+  if (element.attachedCallback || element.detachedCallback || (element.__upgraded__ && logFlags.dom)) {
     logFlags.dom && console.group('inserted:', element.localName);
     if (inDocument(element)) {
       element.__inserted = (element.__inserted || 0) + 1;
@@ -193,7 +193,7 @@ function removed(element) {
 function _removed(element) {
   // TODO(sjmiles): temporary: do work on all custom elements so we can track
   // behavior even when callbacks not defined
-  if (element.__upgraded__) {
+  if (element.attachedCallback || element.detachedCallback || (element.__upgraded__ && logFlags.dom)) {
     logFlags.dom && console.group('removed:', element.localName);
     if (!inDocument(element)) {
       element.__inserted = (element.__inserted || 0) - 1;

--- a/test/js/customElements.js
+++ b/test/js/customElements.js
@@ -243,6 +243,41 @@
     xboo.setAttribute('foo', 'zot');
   });
 
+test('document.register detachedCallbacks in prototype', function(done) {
+    var ready, inserted, removed;
+    var XBooPrototype = Object.create(HTMLElement.prototype);
+    XBooPrototype.detachedCallback = function() {
+      removed = true;
+    }
+    var XBoo = document.registerElement('x-boo-ir2', {
+      prototype: XBooPrototype
+    });
+    var xboo = new XBoo();
+    assert(!removed, 'removed must be false [XBoo]');
+    work.appendChild(xboo);
+    CustomElements.takeRecords();
+    work.removeChild(xboo);
+    CustomElements.takeRecords();
+    assert(removed, 'removed must be true [XBoo]');
+    //
+    ready = inserted = removed = false;
+    var XBooBooPrototype = Object.create(XBooPrototype);
+    XBooBooPrototype.detachedCallback = function() {
+      XBoo.prototype.detachedCallback.call(this);
+    };
+    var XBooBoo = document.registerElement('x-booboo-ir2', {
+      prototype: XBooBooPrototype
+    });
+    var xbooboo = new XBooBoo();
+    assert(!removed, 'removed must be false [XBooBoo]');
+    work.appendChild(xbooboo);
+    CustomElements.takeRecords();
+    work.removeChild(xbooboo);
+    CustomElements.takeRecords();
+    assert(removed, 'removed must be true [XBooBoo]');
+    done();
+  });
+
   test('document.register can use Functions as definitions', function() {
     // function used as Custom Element defintion
     function A$A() {

--- a/test/js/customElements.js
+++ b/test/js/customElements.js
@@ -173,7 +173,6 @@
     assert.equal(xbooboo.style.fontSize, '32pt');
   });
 
-
   test('document.register [created|attached|detached]Callbacks in prototype', function(done) {
     var ready, inserted, removed;
     var XBooPrototype = Object.create(HTMLElement.prototype);
@@ -243,7 +242,30 @@
     xboo.setAttribute('foo', 'zot');
   });
 
-test('document.register detachedCallbacks in prototype', function(done) {
+  test('document.register attachedCallbacks in prototype', function(done) {
+    var inserted = 0;
+    var XBooPrototype = Object.create(HTMLElement.prototype);
+    XBooPrototype.attachedCallback = function() {
+      inserted++;
+    };
+    var XBoo = document.registerElement('x-boo-at', {
+      prototype: XBooPrototype
+    });
+    var xboo = new XBoo();
+    assert.equal(inserted, 0, 'inserted must be 0');
+    work.appendChild(xboo);
+    CustomElements.takeRecords();
+    assert.equal(inserted, 1, 'inserted must be 1');
+    work.removeChild(xboo);
+    CustomElements.takeRecords();
+    assert(!xboo.parentNode);
+    work.appendChild(xboo);
+    CustomElements.takeRecords();
+    assert.equal(inserted, 2, 'inserted must be 2');
+    done();
+  });
+
+  test('document.register detachedCallbacks in prototype', function(done) {
     var ready, inserted, removed;
     var XBooPrototype = Object.create(HTMLElement.prototype);
     XBooPrototype.detachedCallback = function() {


### PR DESCRIPTION
While looking at the relevant code in Observer.js, I realized that the same problem with detachedCallback in #89 would show up for attachedCallback after the first insertion.
