### PR TITLE
Ensure upgrading element fire attached in tree order

### DIFF
--- a/src/CustomElements.js
+++ b/src/CustomElements.js
@@ -226,8 +226,9 @@ if (useNative) {
     element.__upgraded__ = true;
     // lifecycle management
     created(element);
+    // attachedCallback fires in tree order, call before recursing
+    scope.insertedNode(element);
     // there should never be a shadow root on element at this point
-    // we require child nodes be upgraded before `created`
     scope.upgradeSubtree(element);
     // OUTPUT
     return element;

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -98,7 +98,6 @@ function insertedNode(node) {
   }
 }
 
-
 // TODO(sorvell): on platforms without MutationObserver, mutations may not be
 // reliable and therefore attached/detached are not reliable.
 // To make these callbacks less likely to fail, we defer all inserts and removes
@@ -335,6 +334,7 @@ scope.watchShadow = watchShadow;
 scope.upgradeDocumentTree = upgradeDocumentTree;
 scope.upgradeAll = addedNode;
 scope.upgradeSubtree = addedSubtree;
+scope.insertedNode = insertedNode;
 
 scope.observeDocument = observeDocument;
 scope.upgradeDocument = upgradeDocument;

--- a/test/js/customElements.js
+++ b/test/js/customElements.js
@@ -369,6 +369,50 @@
     assert.deepEqual(invocations, ['created', 'entered', 'left'],
         'created, entered then left view');
   });
+
+  test('attachedCallback ordering', function() {
+    var log = [];
+    var p = Object.create(HTMLElement.prototype);
+    p.attachedCallback = function() {
+      log.push(this.id);
+    };
+    document.registerElement('x-boo-ordering', {prototype: p});
+
+    work.innerHTML =
+        '<x-boo-ordering id=a>' +
+          '<x-boo-ordering id=b></x-boo-ordering>' +
+          '<x-boo-ordering id=c>' +
+            '<x-boo-ordering id=d></x-boo-ordering>' +
+            '<x-boo-ordering id=e></x-boo-ordering>' +
+          '</x-boo-ordering>' +
+        '</x-boo-ordering>';
+
+    CustomElements.takeRecords();
+    assert.deepEqual(['a', 'b', 'c', 'd', 'e'], log);
+  });
+
+  test('detachedCallback ordering', function() {
+    var log = [];
+    var p = Object.create(HTMLElement.prototype);
+    p.detachedCallback = function() {
+     log.push(this.id);
+    };
+    document.registerElement('x-boo2-ordering', {prototype: p});
+
+    work.innerHTML =
+        '<x-boo2-ordering id=a>' +
+          '<x-boo2-ordering id=b></x-boo2-ordering>' +
+          '<x-boo2-ordering id=c>' +
+            '<x-boo2-ordering id=d></x-boo2-ordering>' +
+            '<x-boo2-ordering id=e></x-boo2-ordering>' +
+          '</x-boo2-ordering>' +
+        '</x-boo2-ordering>';
+
+      CustomElements.takeRecords();
+      work.innerHTML = '';
+      CustomElements.takeRecords();
+      assert.deepEqual(['a', 'b', 'c', 'd', 'e'], log);
+  });
 });
 
 htmlSuite('customElements (html)', function() {


### PR DESCRIPTION
If elements are inserted and upgrading at the same time, explicitly call the attachedCallback before recursing into
children

Fixes #96

Add test

Add ordering test for detachedCallback
