### PR TITLE
Fix __proto__ leaked as an enumberable on Object.prototype

### DIFF
--- a/src/CustomElements.js
+++ b/src/CustomElements.js
@@ -211,7 +211,12 @@ if (useNative) {
       var proto = definition.prototype, ancestor;
       while (proto && (proto !== nativePrototype)) {
         var ancestor = Object.getPrototypeOf(proto);
-        proto.__proto__ = ancestor;
+        Object.defineProperty(proto, '__proto__', {
+          enumerable: false,
+          configurable: true,
+          writable: true,
+          value: ancestor
+        });
         proto = ancestor;
       }
     }

--- a/test/js/upgrade.js
+++ b/test/js/upgrade.js
@@ -114,6 +114,20 @@ suite('upgradeElements', function() {
     });
   });
 
+  test('__proto__ property isnt leaked as enumerable', function() {
+    document.registerElement('x-button2', {
+      prototype: Object.create(HTMLElement.prototype),
+      'extends': 'button'
+    });
+
+    var name, obj = {};
+    for (name in obj) {
+      if (name === '__proto__') {
+        assert.ok(false, 'obj.__proto__ is enumerable');
+      }
+    }
+  });
+
   // polyfill only tests
   if (!CustomElements.useNative) {
     test('unresolved attribute removed after upgrade', function() {

--- a/test/js/upgrade.js
+++ b/test/js/upgrade.js
@@ -115,9 +115,9 @@ suite('upgradeElements', function() {
   });
 
   test('__proto__ property isnt leaked as enumerable', function() {
-    document.registerElement('x-button2', {
+    document.registerElement('x-time', {
       prototype: Object.create(HTMLElement.prototype),
-      'extends': 'button'
+      'extends': 'time'
     });
 
     var name, obj = {};


### PR DESCRIPTION
As Prototype.js would go on to show, anything you leak a enumerable property on every object by adding it to `Object.prototype` you pretty much break all JS.

In environments that don't support `__proto__` (IE), this "prototype swizzling" hack defines `__proto__` on `Object.prototype` as an **enumberable** property. The bug is only surfaced when `extends` is used.

Though, it also seems like this loop is supposed to stop before it rejects a `nativePrototype`. I'd rather not see `Object.prototype.__proto__` not set at all, but I'm not sure what kind of black magic this hack depends on.

/cc @azakus @zenorocha @arv
